### PR TITLE
Playlist 03 - User Able To Delete Playlist

### DIFF
--- a/src/main/java/com/audiogalaxy/audiogalaxy/controller/PlaylistController.java
+++ b/src/main/java/com/audiogalaxy/audiogalaxy/controller/PlaylistController.java
@@ -55,4 +55,15 @@ public class PlaylistController {
     public List<Song> getSongsByPlaylist(@PathVariable Long playlistId) throws InformationNotFoundException {
         return playlistService.getSongByPlaylistId(playlistId);
     }
+
+    /**
+     * Calls method to delete specific playlist of currently logged-in user
+     * @param playlistId Id of playlist wanting to delete.
+     * @return Deleted playlist
+     * @throws InformationNotFoundException If an error occurs.
+     */
+    @DeleteMapping(path = "/playlists/{playlistId}/")
+    public Playlist deletePlaylist(@PathVariable Long playlistId) throws InformationNotFoundException {
+        return playlistService.deletePlaylistId(playlistId);
+    }
 }

--- a/src/main/java/com/audiogalaxy/audiogalaxy/model/Playlist.java
+++ b/src/main/java/com/audiogalaxy/audiogalaxy/model/Playlist.java
@@ -1,5 +1,8 @@
 package com.audiogalaxy.audiogalaxy.model;
 
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
+
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +31,7 @@ public class Playlist {
             joinColumns = @JoinColumn(name = "playlist_id"),
             inverseJoinColumns = @JoinColumn(name = "song_id")
     )
+    @LazyCollection(LazyCollectionOption.FALSE)
     private List<Song> songs = new ArrayList<>();
 
     public Playlist() {

--- a/src/main/java/com/audiogalaxy/audiogalaxy/repository/PlaylistRepository.java
+++ b/src/main/java/com/audiogalaxy/audiogalaxy/repository/PlaylistRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
     List<Playlist> findByUserId(Long userId);
+    Optional<Playlist> findByIdAndUserId(Long playListId, Long userId);
 }

--- a/src/main/java/com/audiogalaxy/audiogalaxy/service/PlaylistService.java
+++ b/src/main/java/com/audiogalaxy/audiogalaxy/service/PlaylistService.java
@@ -73,5 +73,20 @@ public class PlaylistService {
             throw new InformationNotFoundException("Playlist with id " + playlistId + " is not found");
         }
     }
+
+    /**
+     * Method deletes specified playlist for current logged-in user.
+     * @param playlistId
+     * @return
+     */
+    public Playlist deletePlaylistId(Long playlistId) {
+        Optional<Playlist> playlist = playlistRepository.findByIdAndUserId(playlistId, userContext.getCurrentLoggedInUser().getId());
+        if (playlist.isPresent()) {
+            playlistRepository.deleteById(playlistId);
+            return playlist.get();
+        } else {
+            throw new InformationNotFoundException("User's Playlist with id " + playlistId + " is not found");
+        }
+    }
 }
 

--- a/src/test/java/com/audiogalaxy/audiogalaxy/PlaylistControllerTest.java
+++ b/src/test/java/com/audiogalaxy/audiogalaxy/PlaylistControllerTest.java
@@ -143,4 +143,28 @@ public class PlaylistControllerTest {
                 .andExpect(status().isNotFound())
                 .andDo(print());
     }
+
+    @Test
+    @DisplayName("return 200 and playlist that was deleted")
+    public void shouldDeletePlaylistSuccessfully() throws Exception {
+        when(playlistService.deletePlaylistId(anyLong())).thenReturn((playlist));
+
+        MockHttpServletRequestBuilder mockRequest = MockMvcRequestBuilders.delete("/api/playlists/{playlistId}/", 1);
+
+        mockMvc.perform(mockRequest)
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("return 404 if playlist is not found")
+    public void shouldDeletePlaylistUnsuccessfully() throws Exception {
+        when(playlistService.deletePlaylistId(anyLong())).thenThrow(new InformationNotFoundException("Playlist with id 1 is not found"));
+
+        MockHttpServletRequestBuilder mockRequest = MockMvcRequestBuilders.delete("/api/playlists/{playlistId}/", 1);
+
+        mockMvc.perform(mockRequest)
+                .andExpect(status().isNotFound())
+                .andDo(print());
+    }
 }

--- a/src/test/java/com/audiogalaxy/audiogalaxy/PlaylistServiceTest.java
+++ b/src/test/java/com/audiogalaxy/audiogalaxy/PlaylistServiceTest.java
@@ -142,4 +142,32 @@ public class PlaylistServiceTest {
         Assertions.assertThrows(InformationNotFoundException.class, () -> playlistService.getSongByPlaylistId(2l));
     }
 
+    @Test
+    @DisplayName("return playlist that was deleted as informational")
+    public void testDeletePlaylistSuccessfully() {
+        User currentlyLoggedInUser = new User("jeff", "jeff@gmail.com", "password");
+        when(userContext.getCurrentLoggedInUser()).thenReturn(currentlyLoggedInUser);
+
+        Playlist playlist = new Playlist("jazz music", "jazzy description");
+        playlist.getSongs().add(new Song("Jazz For The Quiet Times", "Smooth Jazz"));
+
+        when(playlistRepository.findByIdAndUserId(anyLong(), anyLong())).thenReturn(Optional.of(playlist));
+
+        Assertions.assertThrows(Exception.class, () -> playlistService.deletePlaylistId(playlist.getId()));
+    }
+
+    @Test
+    @DisplayName("return playlist that was deleted as informational")
+    public void testDeletePlaylistUnsuccessfully() {
+        User currentlyLoggedInUser = new User("jeff", "jeff@gmail.com", "password");
+        when(userContext.getCurrentLoggedInUser()).thenReturn(currentlyLoggedInUser);
+
+        Playlist playlist = new Playlist("jazz music", "jazzy description");
+        playlist.getSongs().add(new Song("Jazz For The Quiet Times", "Smooth Jazz"));
+
+        when(playlistRepository.findByIdAndUserId(anyLong(), anyLong())).thenReturn(Optional.of(playlist));
+
+        Assertions.assertThrows(InformationNotFoundException.class, () -> playlistService.deletePlaylistId(playlist.getId()));
+    }
+
 }

--- a/src/test/java/com/audiogalaxy/audiogalaxy/PlaylistServiceTest.java
+++ b/src/test/java/com/audiogalaxy/audiogalaxy/PlaylistServiceTest.java
@@ -10,6 +10,7 @@ import com.audiogalaxy.audiogalaxy.security.MyUserDetails;
 import com.audiogalaxy.audiogalaxy.security.MyUserDetailsService;
 import com.audiogalaxy.audiogalaxy.security.UserContext;
 import com.audiogalaxy.audiogalaxy.service.PlaylistService;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +21,8 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -138,4 +141,5 @@ public class PlaylistServiceTest {
 
         Assertions.assertThrows(InformationNotFoundException.class, () -> playlistService.getSongByPlaylistId(2l));
     }
+
 }


### PR DESCRIPTION
## Description

Added feature to handle user deleting their playlist and sending a 200 response on a success and a 404 on an unsuccess.

## Type of change

Please select one option:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

Please review the following items and ensure they have been addressed:

- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] My changes generate no new warnings or errors
- [ ] I have updated the version number (if applicable)
- [x] I have tested my changes thoroughly

## Ticket number

[PLAYLIST-03](https://github.com/pophero110/AudioGalaxy-stream-APIs/pull/new/PLAYLIST-03)

## Additional context

Add any other context or screenshots about the pull request here.
